### PR TITLE
Paintera assignments

### DIFF
--- a/example.py
+++ b/example.py
@@ -1,3 +1,4 @@
+import argparse
 
 import os
 from paintera_multicut_workflow import pm_workflow
@@ -5,8 +6,16 @@ from paintera_multicut_workflow import pm_workflow
 
 if __name__ == '__main__':
 
-    # TODO: Set this!
-    results_folder = '/path/to/results/'
+    command = 'source /g/kreshuk/pape/Work/software/conda/miniconda3/bin/activate'
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument('result_folder', type=str)
+    parser.add_argument('--paintera_env_name', type=str, default='paintera')
+    parser.add_argument('--activation_command', type=str, default=command)
+    args = parser.parse_args()
+    results_folder = args.result_folder
+    paintera_env_name = args.paintera_env_name
+    activation_command = args.activation_command
 
     if not os.path.exists(results_folder):
         os.mkdir(results_folder)
@@ -34,8 +43,8 @@ if __name__ == '__main__':
         mem_pred_channel=2,
         auto_crop_center=True,
         annotation_shape=(256, 256, 256),
-        paintera_env_name='paintera_env_new',
-        activation_command='source /home/hennies/miniconda3/bin/activate',
+        paintera_env_name=paintera_env_name,
+        activation_command=activation_command,
         export_binary=True,
         conncomp_on_paintera_export=True,
         verbose=True

--- a/example.py
+++ b/example.py
@@ -6,22 +6,26 @@ from paintera_multicut_workflow import pm_workflow
 
 if __name__ == '__main__':
 
-    command = 'source /g/kreshuk/pape/Work/software/conda/miniconda3/bin/activate'
+    # TODO these should not be default args
+    default_inputs_folder = '/home/pape/Work/data/julian/paintera_mc_wf_example_package'
+    default_command = 'source /g/kreshuk/pape/Work/software/conda/miniconda3/bin/activate'
 
     parser = argparse.ArgumentParser()
     parser.add_argument('result_folder', type=str)
-    parser.add_argument('--paintera_env_name', type=str, default='paintera')
-    parser.add_argument('--activation_command', type=str, default=command)
+    parser.add_argument('--inputs_folder', type=str, default=default_inputs_folder)
+    parser.add_argument('--paintera_env_name', type=str, default='paintera3')
+    parser.add_argument('--activation_command', type=str, default=default_command)
+
     args = parser.parse_args()
     results_folder = args.result_folder
+    inputs_folder = args.inputs_folder
     paintera_env_name = args.paintera_env_name
     activation_command = args.activation_command
 
     if not os.path.exists(results_folder):
         os.mkdir(results_folder)
 
-    inputs_folder = '/g/schwab/hennies/FOR_CONSTANTIN/paintera_mc_wf_example_package'
-
+    # TODO don't hard-code this, but also take as input args
     raw_filepath = os.path.join(
         inputs_folder,
         'raw/train2_x1390_y230_z561_pad.h5'
@@ -40,7 +44,7 @@ if __name__ == '__main__':
         raw_filepath=raw_filepath,
         mem_pred_filepath=mem_filepath,
         supervoxel_filepath=sv_filepath,
-        mem_pred_channel=2,
+        mem_pred_channel=None,
         auto_crop_center=True,
         annotation_shape=(256, 256, 256),
         paintera_env_name=paintera_env_name,

--- a/paintera_multicut_workflow.py
+++ b/paintera_multicut_workflow.py
@@ -19,7 +19,7 @@ try:
 except:
     print('Warning: Napari not imported.')
 
-from svm_tools.paintera_merge import convert_pre_merged_labels_to_paintera
+from svm_tools.paintera_merge import convert_pre_merged_labels_to_assignments
 from svm_tools.label_operations import relabel_consecutive
 from svm_tools.volume_operations import crop_center
 
@@ -208,7 +208,7 @@ def prepare_for_paintera(paintera_env_name, filepath, target_filepath,
 
 
 def export_from_paintera(paintera_env_name, filepath, target_filepath,
-                        activation_command='source activate', shell='/bin/bash', verbose=False):
+                         activation_command='source activate', shell='/bin/bash', verbose=False):
     if verbose:
         console_output = None
     else:
@@ -350,7 +350,7 @@ def paintera_merging_module(
     if not os.path.exists(os.path.join(results_folder, 'raw.n5')):
         print('\n>>> SHELL >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>\n')
         prepare_for_paintera(paintera_env_name, full_raw_filepath, os.path.join(results_folder, 'raw.n5'),
-                              activation_command, shell, verbose=verbose)
+                             activation_command, shell, verbose=verbose)
         print('\n<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<\n')
     if mem_pred_filepath is not None:
         if verbose:
@@ -358,14 +358,14 @@ def paintera_merging_module(
         if not os.path.exists(os.path.join(results_folder, 'mem.n5')):
             print('\n>>> SHELL >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>\n')
             prepare_for_paintera(paintera_env_name, mem_pred_filepath, os.path.join(results_folder, 'mem.n5'),
-                                  activation_command, shell, verbose=verbose)
+                                 activation_command, shell, verbose=verbose)
             print('\n<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<\n')
     if verbose:
         print('Preparing supervoxels ...')
     if not os.path.exists(os.path.join(results_folder, 'sv.n5')):
         print('\n>>> SHELL >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>\n')
         prepare_for_paintera(paintera_env_name, supervoxel_filepath, supervoxel_proj_path,
-                              activation_command, shell, verbose=verbose)
+                             activation_command, shell, verbose=verbose)
         print('\n<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<\n')
 
     if not os.path.exists(os.path.join(paintera_proj_path, 'attributes.json')):
@@ -395,7 +395,7 @@ def paintera_merging_module(
     if not os.path.exists(paintera_lock_file):
         print('\nIntegrating pre-merged segmentation into Paintera project ...')
         # 6. Integrate Multicut result to the paintera project
-        convert_pre_merged_labels_to_paintera(
+        convert_pre_merged_labels_to_assignments(
             supervoxel_filepath, seg_filepath, paintera_proj_path
         )
         open(paintera_lock_file, 'a').close()
@@ -416,7 +416,7 @@ def paintera_merging_module(
     #    > paintera-convert to-scalar --consider-fragment-segment-assignment ...
     print('Exporting from paintera ...')
     export_from_paintera(paintera_env_name, supervoxel_proj_path, os.path.join(results_folder, 'exported_seg.h5'),
-                          activation_command, shell)
+                         activation_command, shell)
 
 
 def paintera_merging_module2(
@@ -452,7 +452,7 @@ def paintera_merging_module2(
     if True:
         print('\n>>> SHELL >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>\n')
         prepare_for_paintera(paintera_env_name, full_raw_filepath, os.path.join(tmp_dir, 'raw.n5'),
-                              activation_command, shell)
+                             activation_command, shell)
         print('\n<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<\n')
     # if mem_pred_filepath is not None:
     #     if verbose:
@@ -475,7 +475,7 @@ def paintera_merging_module2(
     if True:
         print('\n>>> SHELL >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>\n')
         prepare_for_paintera(paintera_env_name, supervoxel_filepath, supervoxel_proj_path,
-                              activation_command, shell)
+                             activation_command, shell)
         print('\n<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<\n')
 
     if not os.path.exists(os.path.join(paintera_proj_path, 'attributes.json')):
@@ -502,11 +502,12 @@ def paintera_merging_module2(
     else:
         print('\nPaintera project exists ...')
 
+    # TODO why is there an if True here?
     # if not os.path.exists(paintera_lock_file):
     if True:
         print('\nIntegrating pre-merged segmentation into Paintera project ...')
         # 6. Integrate Multicut result to the paintera project
-        convert_pre_merged_labels_to_paintera(
+        convert_pre_merged_labels_to_assignments(
             supervoxel_filepath, seg_filepath, paintera_proj_path
         )
         open(paintera_lock_file, 'a').close()
@@ -529,7 +530,7 @@ def paintera_merging_module2(
     if export_filepath is None:
         export_filepath = os.path.join(results_folder, '{}.h5'.format(export_name))
     export_from_paintera(paintera_env_name, supervoxel_proj_path, export_filepath,
-                          activation_command, shell)
+                         activation_command, shell)
 
     if conncomp_on_paintera_export or result_dtype is not None:
         with open_file(export_filepath, mode='r') as f:

--- a/svm_tools/paintera_merge.py
+++ b/svm_tools/paintera_merge.py
@@ -1,86 +1,48 @@
-
-import numpy as np
 import os
-from h5py import File
-import json
+import h5py
+import numpy as np
+import z5py
 
 
-def get_actions_from_label_maps(sv, merged_sv):
+def get_assignments_from_labels(sv, merged_sv):
+    # NOTE we use the indices of np.unique to get the associated segment ids
+    # this assumes that sv and merged_sv are perfectly aligned, otherwise one would
+    # need to assign based on max overlaps
+    fragment_ids, indices = np.unique(sv, return_index=True)
+    segment_ids = merged_sv.ravel()[indices]
 
-    merge_actions = []
-    sv_max = sv.max()
+    # fragment_ids and segment_ids need to be disjoint, so we offset the segment ids with
+    # the max fragment id
+    max_frag_id = int(fragment_ids.max())
+    segment_ids += max_frag_id
 
-    # Iterate over each object in the merged version
-    for idx in np.unique(merged_sv):
-
-        # print('IDX = {}'.format(idx))
-
-        # Get the supervoxels from each object
-        sv_ids = np.unique(sv[merged_sv == idx])
-
-        # print('SV_IDS = {}'.format(sv_ids))
-
-        # Generate merge action strings
-        ref_idx = 0
-        for count_idx, sv_idx in enumerate(sv_ids):
-
-            if count_idx == 0:
-                ref_idx = sv_idx
-
-            else:
-                merge_actions.append(
-                    dict(
-                        type='MERGE',
-                        data=dict(
-                            fromFragmentId=int(sv_idx),
-                            intoFragmentId=int(ref_idx),
-                            segmentId=int(idx + sv_max + 1)
-                        )
-                    )
-                )
-
-    return merge_actions
+    # paintera assignment format:
+    # [[frag_id1, seg_id1], [frag_id2, seg_id1], ..., [frag_idN, seg_idM]]
+    assignments = np.concatenate([fragment_ids[:, None], segment_ids[:, None]], axis=1).T
+    return assignments
 
 
-def write_actions_to_attributes(actions, paintera_proj_path):
-
-    attributes_fp = os.path.join(paintera_proj_path, 'attributes.json')
-    with open(attributes_fp, mode='r') as f:
-        data = json.load(f)
-
-    for sidx, source in enumerate(data['paintera']['sourceInfo']['sources']):
-        if source['type'] == 'org.janelia.saalfeldlab.paintera.state.LabelSourceState':
-            data['paintera']['sourceInfo']['sources'][sidx]['state']['assignment']['data']['actions'] = actions
-
-    with open(attributes_fp, mode='w') as f:
-        json.dump(data, f)
+def write_assignments_to_paintera_format(assignments, data_path, paintera_prefix):
+    with z5py.File(data_path) as f:
+        g = f[paintera_prefix]
+        ds = g.require_dataset('fragment-segment-assignment', shape=assignments.shape, compression='gzip',
+                               chunks=assignments.shape, dtype=assignments.dtype)
+        ds[:] = assignments
 
 
-def convert_pre_merged_labels_to_paintera(sv_filepath, merged_filepath, paintera_proj_path):
+# NOTE for now we nned to weirdly hard-code the path to the data, because it is stored in the 'sv.n5' file
+# in the top-dir of paintera_project_path.
+# I would recommend to restructure this and have everything in one 'data.n5' container.
+# And then pass this data-path and the paintera data prefix to this function
+def convert_pre_merged_labels_to_assignments(sv_filepath, merged_filepath, paintera_proj_path):
+    """ Accumulate node labels for superpixels and write out paintera fragment-segment-assignment format
     """
-    This function integrates merged supervoxels into paintera.
-
-    The workflow:
-    1. Merge supervoxels with any method (e.g. Multicut) and save result as HDF5 (as label map)
-    2. Create a paintera project and load the supervoxel map as label image
-    3. Close the paintera project
-    4. Run this function with following parameters:
-
-    :param sv_filepath: Path to a h5 file containing the supervoxels
-    :param merged_filepath: Path to a h5 file containing the segmentation
-                Note: This segmentation must be obtained by MERGING supervoxels ONLY! Otherwise this script fails
-    :param paintera_proj_path: The path to the paintera project
-    
-    5. Open the paintera project again. The supervoxels are now merged according to the merges performed in step 1 but
-        can be split off again if necessary.
-
-    """
-
-    with File(merged_filepath, mode='r') as f:
+    with h5py.File(merged_filepath, mode='r') as f:
         merged_sv = f['data'][:]
 
-    with File(sv_filepath, mode='r') as f:
+    with h5py.File(sv_filepath, mode='r') as f:
         sv = f['data'][:]
 
-    acts = get_actions_from_label_maps(sv, merged_sv)
-    write_actions_to_attributes(acts, paintera_proj_path)
+    assignments = get_assignments_from_labels(sv, merged_sv)
+    data_path = os.path.join(os.path.split(paintera_proj_path)[0], 'sv.n5')
+    write_assignments_to_paintera_format(assignments, data_path, 'data')


### PR DESCRIPTION
- write `fragment-segment-assignments` dataset instead of actions
- add argparse to the example script
- fix some lint

@jhennies I have tested it, and the script runs through with these changes.
I have not checked if it actually displays things in paintera properly.

In theory it should not be necessary any more to open and reopen paintera with these changes.