### PR TITLE
WIP Napari

### DIFF
--- a/paintera_multicut_workflow.py
+++ b/paintera_multicut_workflow.py
@@ -252,6 +252,25 @@ def open_napari(data):
             elif item['type'] == 'raw':
                 viewer.add_image(item['data'], name=item['name'], visible=item['visible'])
 
+        @viewer.bind_key('q')
+        def quit(viewer):
+            pass
+
+        @viewer.bind_key('h')
+        def help(viewer):
+            # TODO refactor this into a function, so it can be called from elsewhere
+            print('            exit / q      -> finish assignments and export')
+            print('            update / u    -> updates Napari display')
+            print('            editor / e    -> re-opens editor')
+
+        @viewer.bind_key('u')
+        def update(viewer):
+            pass
+
+        @viewer.bind_key('e')
+        def editor(viewer):
+            pass
+
     return None
 
 

--- a/paintera_multicut_workflow.py
+++ b/paintera_multicut_workflow.py
@@ -658,9 +658,13 @@ def organelle_assignment_module(
             layers = viewer.layers
             for name, data in new_organelle_maps.items():
                 is_visible = name == 'MISC'
-                if name in layers:
+                # if name in layers:
+                try:
+                    # This raises a key error if the layer does not exist
+                    # FIXME is there a solution like 'if name in layers: ...' that does not error out?
+                    name in layers
                     layers[name].data = data
-                else:
+                except KeyError:
                     viewer.add_labels(data, name=name, visible=is_visible)
             print("... done")
 


### PR DESCRIPTION
- Run napari in mainprocess
- Use napari keybindings instead of terminal commands

Still WIP because:
- Not tested at all
- Once corner case is not properly addressed: if a category is removed from the json, the napari layer will persist and not be removed properly. (Should be easy to fix).
- Also, proper error handling for parsing the json should be added to deal with syntax errors more robustly